### PR TITLE
chore: gitignore node_modules + package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 build/
 venv/
 *.egg-info/
+node_modules/
+frontend/package-lock.json


### PR DESCRIPTION
Prevents frontend build artifacts from dirtying the working tree.